### PR TITLE
Update I/O procedures and fix typos

### DIFF
--- a/srfi-207.html
+++ b/srfi-207.html
@@ -116,12 +116,6 @@
 
 <h3>Conversion</h3>
 
-<p><code>(bytestring-&gt;string</code>&nbsp;<var>bytestring</var> [ <var>v</var> ]<code>)</code></p>
-<p>Convert a bytevector to the corresponding string in the external format described in this SRFI. If the <var>v</var> argument is present and true, a <code>#\v</code> is prefixed to the string for compatibility with R6RS.</p>
-<code>(string-&gt;bytestring</code>&nbsp;<var>string</var><code>)</code>
-<p>Convert a string in the external format described in this SRFI to the corresponding bytevector. If the first character is a <code>#\v</code>, it is ignored.
-If <var>string</var> is not in the external format, an error satisfying <code>bytestring-error?</code> is raised.</p>
-
 <p><code>(bytestring-&gt;hex-string</code>&nbsp;<var>bytestring</var><code>)</code><br>
 <code>(hex-string-&gt;bytestring</code>&nbsp;<var>string</var><code>)</code></p>
 <p>Convert between a bytevector and a string containing pairs of hexadecimal digits.
@@ -204,9 +198,20 @@ are silently ignored.
 <p>Divides the elements of <var>bytevector</var> and returns a list of bytevectors using the <var>delimiter</var> (an ASCII character or exact integer in the range 0-255 inclusive). Delimiter bytes are not included in the result bytevectors.</p>
 <p>The <var>grammar</var> argument is used to control how <var>bytevector</var> is divided. It has the same default and meaning as in <code>bytestring-join</code>, except that <code>infix</code> and <code>strict-infix</code> mean the same thing. That is, if <var>grammar</var> is <code>prefix</code> or <code>suffix</code>, then ignore any delimiter in the first or last position of <var>bytevector</var> respectively.</p>
 
-<h3>Output</h3>
+<h3>I/O</h3>
 
-<p><code>(write-bytestring</code>&nbsp;<var>port arg</var> …<code>)</code></p>
+<code>(read-textual-bytestring</code>&nbsp; [ <var>port</var> ]<code>)</code>
+<p>Read a string in the external format described in this SRFI
+from <var>port</var> and return it as a bytevector.
+If <var>port</var> is omitted, it defaults to the value of <code>(current-input-port)</code>.
+If the characters read are not in the external format,
+an error satisfying <code>bytestring-error?</code> is raised.</p>
+
+<p><code>(write-textual-bytestring</code>&nbsp;<var>bytestring</var> [ <var>port</var> ]<code>)</code></p>
+<p>Write <var>bytestring</var> in the external format described in this SRFI. to <var>port</var>.
+If <var>port</var> is omitted, it defaults to the value of <code>(current-input-port)</code>.</p>
+
+<p><code>(write-binary-bytestring</code>&nbsp;<var>port arg</var> …<code>)</code></p>
 <p>Outputs each <var>arg</var> to the binary output port <var>port</var> using the same interpretations as <code>bytestring</code>, but does not create any bytevectors.</p>
 
 <h3>Exception</h3>

--- a/srfi-207.html
+++ b/srfi-207.html
@@ -208,8 +208,8 @@ If the characters read are not in the external format,
 an error satisfying <code>bytestring-error?</code> is raised.</p>
 
 <p><code>(write-textual-bytestring</code>&nbsp;<var>bytestring</var> [ <var>port</var> ]<code>)</code></p>
-<p>Write <var>bytestring</var> in the external format described in this SRFI. to <var>port</var>.
-If <var>port</var> is omitted, it defaults to the value of <code>(current-input-port)</code>.</p>
+<p>Write <var>bytestring</var> in the external format described in this SRFI to <var>port</var>.
+If <var>port</var> is omitted, it defaults to the value of <code>(current-output-port)</code>.</p>
 
 <p><code>(write-binary-bytestring</code>&nbsp;<var>port arg</var> …<code>)</code></p>
 <p>Outputs each <var>arg</var> to the binary output port <var>port</var> using the same interpretations as <code>bytestring</code>, but does not create any bytevectors.</p>

--- a/srfi-207.html
+++ b/srfi-207.html
@@ -217,7 +217,17 @@ If <var>port</var> is omitted, it defaults to the value of <code>(current-output
 <h3>Exception</h3>
 
 <p><code>(bytestring-error?</code>&nbsp;<var>obj</var><code>)</code></p>
-<p>Returns <code>#t</code> if <var>obj</var> is an object signaled by <code>bytestring</code>, <code>list-&gt;bytestring</code>, <code>bytestring-join</code>, <code>bytestring-split</code> or <code>write-bytestring</code> in the circumstances described above.</p>
+<p>Returns <code>#t</code> if <var>obj</var> is an object signaled by any of the
+following procedures, in the circumstances described above:</p>
+<ul>
+  <li><code>bytestring</code></li>
+  <li><code>hex-string-&gt;bytestring</code></li>
+  <li><code>base64-&gt;bytestring</code></li>
+  <li><code>list-&gt;bytestring</code></li>
+  <li><code>bytestring-join</code></li>
+  <li><code>read-textual-bytestring</code></li>
+  <li><code>write-binary-bytestring</code></li>
+</ul>
 
 <h2 id="implementation">Implementation</h2>
 

--- a/srfi/207.sld
+++ b/srfi/207.sld
@@ -83,8 +83,6 @@
     (else (import (only (srfi 160 u8) u8vector-for-each u8vector-unfold))))
 
   (export bytestring list->bytestring bytestring->hex-string bytestring->list
-          bytestring->string
-          string->bytestring
           list->bytestring!
           hex-string->bytestring bytestring->base64 base64->bytestring
           bytestring-pad bytestring-pad-right bytestring-trim
@@ -96,7 +94,8 @@
           bytestring-ci>=?
           bytestring-error? bytestring-error-message bytestring-error-irritants
           bytestring-join bytestring-split
-          write-bytestring)
+          read-textual-bytestring write-textual-bytestring
+          write-binary-bytestring)
 
   (include "207/error.scm")
   (include "207/parse.scm")

--- a/srfi/207/bytestrings-impl.scm
+++ b/srfi/207/bytestrings-impl.scm
@@ -483,6 +483,7 @@
    ((bstring)
     (write-textual-bytestring bstring (current-output-port)))
    ((bstring port)
+    (write-string "#u8\"")
     (u8vector-for-each
      (lambda (b)
        (cond ((and (< b 14) (assv b backslash-codepoints)) =>
@@ -492,7 +493,8 @@
              ((and (>= b #x20) (<= b #x7e))
               (write-char (integer->char b) port))
              (else (bytestring-error "invalid byte" b))))
-     bstring))))
+     bstring)
+    (write-char #\"))))
 
 (define (write-binary-bytestring port . args)
   (assume (binary-port? port))

--- a/srfi/207/bytestrings-impl.scm
+++ b/srfi/207/bytestrings-impl.scm
@@ -73,26 +73,7 @@
 
 ;;;; Conversion
 
-(define backslash-codepoints
-  '((7 . #\a) (8 . #\b) (9 . #\t) (10 . #\n) (13 . #\r)))
-
-(define write-textual-bytestring
-  (case-lambda
-   ((bstring)
-    (write-textual-bytestring bstring (current-output-port)))
-   ((bstring port)
-    (u8vector-for-each
-     (lambda (b)
-       (cond ((and (< b 14) (assv b backslash-codepoints)) =>
-              (lambda (p)
-                (write-char #\\ port)
-                (write-char (cdr p) port)))
-             ((and (>= b #x20) (<= b #x7e))
-              (write-char (integer->char b) port))
-             (else (bytestring-error "invalid byte" b))))
-     bstring))))
-
-;;;; Hex string conversion
+;;; Hex string conversion
 
 ;; Convert an unsigned integer n to a bytevector representing
 ;; the base-256 big-endian form (the zero index holds the MSB).
@@ -492,7 +473,26 @@
           (if (char? delimiter) (char->integer delimiter) delimiter)
           grammar)))))
 
-;;;; Output
+;;;; I/O
+
+(define backslash-codepoints
+  '((7 . #\a) (8 . #\b) (9 . #\t) (10 . #\n) (13 . #\r)))
+
+(define write-textual-bytestring
+  (case-lambda
+   ((bstring)
+    (write-textual-bytestring bstring (current-output-port)))
+   ((bstring port)
+    (u8vector-for-each
+     (lambda (b)
+       (cond ((and (< b 14) (assv b backslash-codepoints)) =>
+              (lambda (p)
+                (write-char #\\ port)
+                (write-char (cdr p) port)))
+             ((and (>= b #x20) (<= b #x7e))
+              (write-char (integer->char b) port))
+             (else (bytestring-error "invalid byte" b))))
+     bstring))))
 
 (define (write-binary-bytestring port . args)
   (assume (binary-port? port))

--- a/srfi/207/parse.scm
+++ b/srfi/207/parse.scm
@@ -61,8 +61,14 @@
       (read-char)
       (lp))))
 
-(define (string->bytestring s)
-  (parameterize ((current-input-port (open-input-string s))
-                 (current-output-port (open-output-bytevector)))
-    (parse)
-    (get-output-bytevector (current-output-port))))
+(define read-textual-bytestring
+  (case-lambda
+   (() (read-textual-bytestring (current-input-port)))
+   ((in)
+    (call-with-port
+     (open-output-bytevector)
+     (lambda (out)
+       (parameterize ((current-input-port in)
+                      (current-output-port out))
+         (parse)
+         (get-output-bytevector out)))))))

--- a/srfi/207/parse.scm
+++ b/srfi/207/parse.scm
@@ -1,8 +1,10 @@
 ;;; Simple parser for string-notated bytevectors.
 
 (define (parse)
+  (consume-prefix)
   (let lp ((c (read-char)))
-    (cond ((eof-object? c) (if #f #f))
+    (cond ((eof-object? c) (bytestring-error "unexpected EOF"))
+          ((char=? c #\") (if #f #f))  ; terminating quote
           ((char=? c #\\)
            (let ((c* (read-char)))
              (cond ((eof-object? c*)
@@ -16,6 +18,12 @@
            (write-u8 (char->integer c))
            (lp (read-char)))
           (else (bytestring-error "invalid character" c)))))
+
+(define (consume-prefix)
+  (let ((s (read-string 4)))
+    (cond ((eof-object? s) (bytestring-error "unexpected EOF"))
+          ((string=? s "#u8\"") #t)
+          (else (bytestring-error "invalid bytestring prefix" s)))))
 
 (define (escape c)
   (case c


### PR DESCRIPTION
This adds and implements John's changes to the bytestring I/O procedures. A few typos and a stale description were also fixed. Please note that the tests are not yet up-to-date with these changes. Thanks.