### PR TITLE
Implementation-only corrections

### DIFF
--- a/srfi-207-test.scm
+++ b/srfi-207-test.scm
@@ -176,8 +176,11 @@
           (base64->bytestring "bG9@frob"))             => 'bytestring-error)
 
   (check (bytestring->list #u8()) => '())
-  (check (bytestring->list test-bstring) => '(#x6c #x6f #x72 #x65 #x6d))
   (check (list->bytestring (bytestring->list test-bstring)) => test-bstring)
+  (check (list->bytestring (bytestring->list test-bstring 2))
+   => (bytestring "rem"))
+  (check (list->bytestring (bytestring->list test-bstring 1 3))
+   => (bytestring "or"))
 
   (let ((bvec (make-bytevector 5)))
     (check (begin

--- a/srfi-207-test.scm
+++ b/srfi-207-test.scm
@@ -113,8 +113,8 @@
 (define (%bytestring->SNB bstring)
   (call-with-port (open-output-string)
                   (lambda (port)
-		    (write-textual-bytestring bstring port)
-		    (get-output-string port))))
+                    (write-textual-bytestring bstring port)
+                    (get-output-string port))))
 
 
 (define test-bstring (bytestring "lorem"))

--- a/srfi/207.sld
+++ b/srfi/207.sld
@@ -7,14 +7,10 @@
 
   (cond-expand
     ((library (scheme bytevector))
-      (import (only (scheme bytevector) bytevector=? bytevector->u8-list
-                                        u8-list->bytevector))
-      (begin
-       (define (bytestring->list bstring)
-         (bytevector->u8-list bstring))))
+     (import (only (scheme bytevector) bytevector->u8-list
+                                       u8-list->bytevector)))
     (else
      (begin
-      (define bytevector=? equal?)
       (define (u8-list->bytevector lis)
         (let* ((len (length lis))
                (bvec (make-bytevector len)))
@@ -22,10 +18,10 @@
             (cond ((null? lis) bvec)
                   (else (bytevector-u8-set! bvec i (car lis))
                         (lp (+ i 1) (cdr lis)))))))
-      (define (bytestring->list bstring)
-        (assume (bytevector? bstring))
-        (list-tabulate (bytevector-length bstring)
-                       (lambda (i) (bytevector-u8-ref bstring i)))))))
+      (define (bytevector->u8-list bvec)
+        (list-tabulate (bytevector-length bvec)
+                       (lambda (i)
+                         (bytevector-u8-ref bvec i)))))))
 
   (cond-expand
     ((library (srfi 133))

--- a/srfi/207/bytestrings-impl.scm
+++ b/srfi/207/bytestrings-impl.scm
@@ -31,6 +31,11 @@
 (define (string-ascii? str)
   (and (string-every (lambda (c) (char<=? c #\delete)) str) #t))
 
+(define (valid-bytestring-segment? obj)
+  (or (bytevector? obj)
+      (u8-or-ascii-char? obj)
+      (and (string? obj) (string-ascii? obj))))
+
 (define (%bytestring-null? bstring)
   (zero? (bytevector-length bstring)))
 
@@ -463,4 +468,8 @@
 
 (define (write-binary-bytestring port . args)
   (assume (binary-port? port))
+  (for-each (lambda (arg)
+              (unless (valid-bytestring-segment? arg)
+                (bytestring-error "invalid bytestring element" arg)))
+            args)
   (for-each (lambda (seg) (%write-bytestring-segment seg port)) args))

--- a/srfi/207/bytestrings-impl.scm
+++ b/srfi/207/bytestrings-impl.scm
@@ -144,6 +144,21 @@
      (assume (string? digits))
      (decode-base64-string base64-string digits))))
 
+;; The SRFI gives us some latitude with this one; as long as the
+;; resulting list can be passed to list->bytestring, we can return
+;; whatever breakdown of bstring we like.  This returns a list of
+;; the bytes of bstring, since that seems least surprising.
+(define bytestring->list
+  (case-lambda
+    ((bstring) (bytestring->list bstring 0 (bytevector-length bstring)))
+    ((bstring start)
+     (bytestring->list bstring start (bytevector-length bstring)))
+    ((bstring start end)
+     (unfold (lambda (i) (= i end))
+             (lambda (i) (bytevector-u8-ref bstring i))
+             (lambda (i) (+ i 1))
+             start))))
+
 ;; Lazily generate the bytestring constructed from objs.
 (define (make-bytestring-generator . objs)
   (list->generator (flatten-bytestring-segments objs)))

--- a/srfi/207/bytestrings-impl.scm
+++ b/srfi/207/bytestrings-impl.scm
@@ -159,6 +159,15 @@
     ((bstring start)
      (bytestring->list bstring start (bytevector-length bstring)))
     ((bstring start end)
+     (assume (bytevector? bstring))
+     (assume (and (exact-natural? start) (>= start 0))
+             "invalid start index"
+             start
+             bstring)
+     (assume (and (exact-natural? end) (<= end (bytevector-length bstring)))
+             "invalid end index"
+             end
+             bstring)
      (unfold (lambda (i) (= i end))
              (lambda (i) (bytevector-u8-ref bstring i))
              (lambda (i) (+ i 1))


### PR DESCRIPTION
This implements and tests the optional arguments of the bytestring->list procedure, which I'd overlooked. There's probably no need for an announcement. Thanks.