### PR TITLE
correct inconsistency between notation description and formal syntax

### DIFF
--- a/srfi-207.html
+++ b/srfi-207.html
@@ -111,7 +111,7 @@ bytestrings and bytevectors are exactly the same type.</p>
       <tr><td><code>\r</code> <td>13
       <tr><td><code>\|</code> <td>124
     </table>
-  <li>the sequence <code>\x</code> followed by one or two hexadecimal digits followed by <code>;</code> represents the integer specified;
+  <li>the sequence <code>\x</code> followed by zero or more <code>0</code> characters, followed by one or two hexadecimal digits, followed by <code>;</code> represents the integer specified by the hexadecimal digits;
   <li>the sequence <code>\</code> followed by zero or more intraline whitespace characters, followed by a newline, followed by zero or more further intraline whitespace characters, is ignored and corresponds to no entry in the resulting bytevector;
   <li>any other printable ASCII character represents the character number of that character in the ASCII/Unicode code chart; and
   <li>it is an error to use any other character or sequence beginning with <code>\</code> within a string-notated bytevector.


### PR DESCRIPTION
Fixes the small thorny inconsistency I mentioned in a mailing list message a few weeks ago.

(Since this is essentially an erratum, I don’t see any need to delay the last call for this.)