### PR TITLE
Examples and minor fixes

### DIFF
--- a/srfi-207-chibi-test.scm
+++ b/srfi-207-chibi-test.scm
@@ -199,7 +199,7 @@
 
 (test-group "bytestring-replace"
   (test (bytestring "lists")
-        (bytestring-replace test-bstring (bytestring "mists") 1 5))
+        (bytestring-replace test-bstring (bytestring "mists") 1 5 1 5))
   (test (bytestring "loaded")
         (bytestring-replace test-bstring (bytestring "faded") 2 5 1 5))
   (test test-bstring

--- a/srfi-207-test.scm
+++ b/srfi-207-test.scm
@@ -254,7 +254,7 @@
 (define (check-replacement)
   (print-header "Running bytestring-replace tests...")
 
-  (check (bytestring-replace test-bstring (bytestring "mists") 1 5)
+  (check (bytestring-replace test-bstring (bytestring "mists") 1 5 1 5)
    => (bytestring "lists"))
   (check (bytestring-replace test-bstring (bytestring "faded") 2 5 1 5)
    => (bytestring "loaded"))

--- a/srfi-207.html
+++ b/srfi-207.html
@@ -174,10 +174,10 @@ result of applying <code>bytestring</code> to <var>list</var>.
 Otherwise, an error satisfying <code>bytestring-error?</code> is signaled.</p>
 
 <p><code>(make-bytestring!</code>&nbsp;<var>bytevector at list</var><code>)</code></p>
-If the elements of <var>list</var> are suitable arguments for
+<p>If the elements of <var>list</var> are suitable arguments for
 <code>bytestring</code>, write the bytes of the bytevector that would be the
 result of calling <code>make-bytevector</code>
-into <var>bytevector</var> starting at index <var>at</var>.
+into <var>bytevector</var> starting at index <var>at</var>.</p>
 <pre class="example"><code>(define bstring (make-bytevector 10 #x20))
 (make-bytestring! bstring 2 '(#\s #\c "he" #u8(#x6d #x65))
 bstring &rArr; #u8"  scheme  "</code></pre>
@@ -199,7 +199,7 @@ Details can be found in
 <a href="https://tools.ietf.org/html/rfc4648">RFC 4648</a>.
 If <var>string</var> is not in base-64 format, an error satisfying <code>bytestring-error?</code> is raised.
 However, characters that satisfy <code>char-whitespace?</code>
-are silently ignored.
+are silently ignored.</p>
 <pre class="example"><code>(bytevector-&gt;base64 #u8(1 2 3 4 5 6)) &rArr; "AQIDBAUG"
 
 (bytevector-&gt;base64 #u8"Arthur Dent") &rArr; "QXJ0aHVyIERlbnQ="

--- a/srfi-207.html
+++ b/srfi-207.html
@@ -165,7 +165,9 @@ so that it is clear that <code>#u8"&iota;"</code> and
 </ul>
 <p>Otherwise, an error satisfying <code>bytestring-error?</code> is signaled.</p>
 <p>Examples:</p>
-<pre class="example"><code>(bytestring "lor" #\r #x65 #u8(#x6d)) &rArr; #u8"lorem"</code></pre>
+<pre class="example"><code>(bytestring "lor" #\r #x65 #u8(#x6d)) &rArr; #u8"lorem"
+(bytestring "&eta;" #\space #u8(#x65 #x71 #x75 #x69 #x76)) &rArr;</code> <em>error</em>
+</code></pre>
 
 <p><code>(make-bytestring</code>&nbsp;<var>list</var><code>)</code></p>
 <p>If the elements of <var>list</var> are suitable arguments for

--- a/srfi-207.html
+++ b/srfi-207.html
@@ -177,7 +177,7 @@ Otherwise, an error satisfying <code>bytestring-error?</code> is signaled.</p>
 
 <p><code>(make-bytestring!</code>&nbsp;<var>bytevector at list</var><code>)</code></p>
 <p>If the elements of <var>list</var> are suitable arguments for
-<code>bytestring</code>, write the bytes of the bytevector that would be the
+<code>bytestring</code>, writes the bytes of the bytevector that would be the
 result of calling <code>make-bytevector</code>
 into <var>bytevector</var> starting at index <var>at</var>.</p>
 <pre class="example"><code>(define bstring (make-bytevector 10 #x20))

--- a/srfi-207.html
+++ b/srfi-207.html
@@ -191,7 +191,6 @@ bstring &rArr; #u8"  scheme  "</code></pre>
 <p>Convert between a bytevector and a string containing pairs of hexadecimal digits.
 If <var>string</var> is not pairs of hexadecimal digits, an error satisfying <code>bytestring-error?</code> is raised.</p>
 <pre class="example"><code>(bytevector-&gt;hex-string #u8"Ford") &rArr; "467f7264"
-
 (hex-string-&gt;bytevector "5a6170686f64") &rArr; #u8"Zaphod"</code></pre>
 
 <p><code>(bytevector-&gt;base64</code>&nbsp;<var>bytevector</var> [<var>digits</var>]<code>)</code><br>
@@ -203,9 +202,7 @@ If <var>string</var> is not in base-64 format, an error satisfying <code>bytestr
 However, characters that satisfy <code>char-whitespace?</code>
 are silently ignored.</p>
 <pre class="example"><code>(bytevector-&gt;base64 #u8(1 2 3 4 5 6)) &rArr; "AQIDBAUG"
-
 (bytevector-&gt;base64 #u8"Arthur Dent") &rArr; "QXJ0aHVyIERlbnQ="
-
 (base64-&gt;bytevector "+/     /+") &rArr; #u8(#xfb #xff #xfe)</code></pre>
 
 <p><code>(bytestring-&gt;list</code>&nbsp;<var>bytevector</var> [ <var>start</var> [ <var>end</var> ] ]<code>)</code></p>
@@ -230,7 +227,6 @@ if they are ill-formed, an error satisfying
 <code>(bytestring-pad-right</code>&nbsp;<var>bytevector len char-or-u8</var><code>)</code></p>
 <p>Returns a newly allocated bytevector with the contents of <var>bytevector</var> plus sufficient additional bytes at the beginning/end containing <var>char-or-u8</var> (which can be either an ASCII character or an exact integer in the range 0-255) such that the length of the result is at least <var>len</var>.</p>
 <pre class="example"><code>(bytestring-pad #u8"Zaphod" 10 #\_) &rArr; #u8"____Zaphod"
-
 (bytestring-pad-right #u8(#x80 #x7f) 8 0) &rArr; #u8(#x80 #x7f 0 0 0 0 0 0)</code></pre>
 
 <p><code>(bytestring-trim</code>&nbsp;<var>bytevector pred</var><code>)</code><br>
@@ -239,7 +235,6 @@ if they are ill-formed, an error satisfying
 <p>Returns a newly allocated bytevector with the contents of <var>bytevector</var>, except that consecutive bytes at the beginning / the end / both the beginning and the end that satisfy <var>pred</var> are not included.</p>
 <pre class="example"><code>(bytestring-trim #u8"   Trillian" (lambda (b) (= b #x20)))
   &rArr; #u8"Trillian"
-
 (bytestring-trim-both #u8(0 0 #x80 #x7f 0 0 0) zero?) &rArr; #u8(#x80 #x7f)</code></pre>
 
 <h3>Replacement</h3>

--- a/srfi-207.html
+++ b/srfi-207.html
@@ -243,7 +243,7 @@ if they are ill-formed, an error satisfying
 <h3>Replacement</h3>
 
 <p><code>(bytestring-replace</code>&nbsp;<var>bytevector1 bytevector2 start1 end1 [start2 end2]</var><code>)</code></p>
-<p>Returns a newly allocated bytevector with the contents of <var>bytevector1</var>, except that the bytes indexed by <var>start1</var> and <var>end1</var> are not included but are replaced by the bytes of <var>bytevector2</var> indexed by <var>start</var> and <var>end</var>.</p>
+<p>Returns a newly allocated bytevector with the contents of <var>bytevector1</var>, except that the bytes indexed by <var>start1</var> and <var>end1</var> are not included but are replaced by the bytes of <var>bytevector2</var> indexed by <var>start2</var> and <var>end2</var>.</p>
 <pre class="example"><code>(bytestring-replace #u8"Vogon torture" #u8"poetry" 6 13)
   &rArr; #u8"Vogon poetry"</code></pre>
 

--- a/srfi-207.html
+++ b/srfi-207.html
@@ -5,6 +5,7 @@
     <title>SRFI 207: String-notated bytevectors</title>
     <link href="/favicon.png" rel="icon" sizes="192x192" type="image/png">
     <link rel="stylesheet" href="https://srfi.schemers.org/srfi.css" type="text/css">
+    <style>pre.example { margin-left: 2em; }</style>
     <meta name="viewport" content="width=device-width, initial-scale=1"></head>
   <body>
     <h1><a href="https://srfi.schemers.org/"><img class="srfi-logo" src="https://srfi.schemers.org/srfi-logo.svg" alt="SRFI logo" /></a>207: String-notated bytevectors</h1>
@@ -163,6 +164,8 @@ so that it is clear that <code>#u8"&iota;"</code> and
   </li>
 </ul>
 <p>Otherwise, an error satisfying <code>bytestring-error?</code> is signaled.</p>
+<p>Examples:</p>
+<pre class="example"><code>(bytestring "lor" #\r #x65 #u8(#x6d)) &rArr; #u8"lorem"</code></pre>
 
 <p><code>(make-bytestring</code>&nbsp;<var>list</var><code>)</code></p>
 <p>If the elements of <var>list</var> are suitable arguments for
@@ -175,6 +178,9 @@ If the elements of <var>list</var> are suitable arguments for
 <code>bytestring</code>, write the bytes of the bytevector that would be the
 result of calling <code>make-bytevector</code>
 into <var>bytevector</var> starting at index <var>at</var>.
+<pre class="example"><code>(define bstring (make-bytevector 10 #x20))
+(make-bytestring! bstring 2 '(#\s #\c "he" #u8(#x6d #x65))
+bstring &rArr; #u8"  scheme  "</code></pre>
 
 <h3>Conversion</h3>
 
@@ -182,6 +188,9 @@ into <var>bytevector</var> starting at index <var>at</var>.
 <code>(hex-string-&gt;bytevector</code>&nbsp;<var>string</var><code>)</code></p>
 <p>Convert between a bytevector and a string containing pairs of hexadecimal digits.
 If <var>string</var> is not pairs of hexadecimal digits, an error satisfying <code>bytestring-error?</code> is raised.</p>
+<pre class="example"><code>(bytevector-&gt;hex-string #u8"Ford") &rArr; "467f7264"
+
+(hex-string-&gt;bytevector "5a6170686f64") &rArr; #u8"Zaphod"</code></pre>
 
 <p><code>(bytevector-&gt;base64</code>&nbsp;<var>bytevector</var> [<var>digits</var>]<code>)</code><br>
 <code>(base64-&gt;bytevector</code>&nbsp;<var>string</var> [<var>digits</var>]<code>)</code></p>
@@ -191,12 +200,18 @@ Details can be found in
 If <var>string</var> is not in base-64 format, an error satisfying <code>bytestring-error?</code> is raised.
 However, characters that satisfy <code>char-whitespace?</code>
 are silently ignored.
+<pre class="example"><code>(bytevector-&gt;base64 #u8(1 2 3 4 5 6)) &rArr; "AQIDBAUG"
+
+(bytevector-&gt;base64 #u8"Arthur Dent") &rArr; "QXJ0aHVyIERlbnQ="
+
+(base64-&gt;bytevector "+/     /+") &rArr; #u8(#xfb #xff #xfe)</code></pre>
 
 <p><code>(bytestring-&gt;list</code>&nbsp;<var>bytevector</var> [ <var>start</var> [ <var>end</var> ] ]<code>)</code></p>
 <p>Convert all or part of a bytevector
 into a list of the same length containing
 characters for elements in the range 32 to 127
 and exact integers for all other elements.</p>
+<pre class="example"><code>(bytestring-&gt;list #u8(#x41 #x42 1 2) 1 3) &rArr; (#\B 1)</code></pre>
 
 <p><code>(make-bytestring-generator</code>&nbsp;<var>arg</var> …<code>)</code></p>
 <p>Returns a generator that when invoked will return consecutive bytes
@@ -205,21 +220,32 @@ to <var>args</var>, but without creating any bytevectors.
 The <var>args</var> are validated before any bytes are generated;
 if they are ill-formed, an error satisfying
 <code>bytestring-error?</code> is raised.</p>
+<pre class="example"><code>(generator->list (make-bytestring-generator "lorem"))
+  &rArr; (#x6c #x6f #x72 #x65 #x6d)</code></pre>
 <h3>Selection</h3>
 
 <p><code>(bytestring-pad</code>&nbsp;<var>bytevector len char-or-u8</var><code>)</code><br>
 <code>(bytestring-pad-right</code>&nbsp;<var>bytevector len char-or-u8</var><code>)</code></p>
 <p>Returns a newly allocated bytevector with the contents of <var>bytevector</var> plus sufficient additional bytes at the beginning/end containing <var>char-or-u8</var> (which can be either an ASCII character or an exact integer in the range 0-255) such that the length of the result is at least <var>len</var>.</p>
+<pre class="example"><code>(bytestring-pad #u8"Zaphod" 10 #\_) &rArr; #u8"____Zaphod"
+
+(bytestring-pad-right #u8(#x80 #x7f) 8 0) &rArr; #u8(#x80 #x7f 0 0 0 0 0 0)</code></pre>
 
 <p><code>(bytestring-trim</code>&nbsp;<var>bytevector pred</var><code>)</code><br>
 <code>(bytestring-trim-right</code>&nbsp;<var>bytevector pred</var><code>)</code><br>
 <code>(bytestring-trim-both</code>&nbsp;<var>bytevector pred</var><code>)</code></p>
 <p>Returns a newly allocated bytevector with the contents of <var>bytevector</var>, except that consecutive bytes at the beginning / the end / both the beginning and the end that satisfy <var>pred</var> are not included.</p>
+<pre class="example"><code>(bytestring-trim #u8"   Trillian" (lambda (b) (= b #x20)))
+  &rArr; #u8"Trillian"
+
+(bytestring-trim-both #u8(0 0 #x80 #x7f 0 0 0) zero?) &rArr; #u8(#x80 #x7f)</code></pre>
 
 <h3>Replacement</h3>
 
 <p><code>(bytestring-replace</code>&nbsp;<var>bytevector1 bytevector2 start1 end1 [start2 end2]</var><code>)</code></p>
 <p>Returns a newly allocated bytevector with the contents of <var>bytevector1</var>, except that the bytes indexed by <var>start1</var> and <var>end1</var> are not included but are replaced by the bytes of <var>bytevector2</var> indexed by <var>start</var> and <var>end</var>.</p>
+<pre class="example"><code>(bytestring-replace #u8"Vogon torture" #u8"poetry" 6 13)
+  &rArr; #u8"Vogon poetry"</code></pre>
 
 <h3>Comparison</h3>
 

--- a/srfi-207.html
+++ b/srfi-207.html
@@ -259,16 +259,32 @@ the equivalent R7RS library <code>(scheme bytevector)</code>.
 <code>bytestring&lt;=?</code> <var>bytevector1 bytevector2</var><code>)</code><br>
 <code>bytestring&gt;=?</code> <var>bytevector1 bytevector2</var><code>)</code></p>
 <p>Returns <code>#t</code> if <var>bytevector1</var> is less than / greater than / less than or equal to / greater than or equal to <var>bytevector2</var>. Comparisons are lexicographical: shorter bytevectors compare before longer ones, all elements being equal.</p>
+<pre class="example"><code>(bytestring&lt;? #u8"Heart Of Gold" #u8"Heart of Gold") &rArr; #t
+(bytestring&lt;=? #u8(#x81 #x95) #u8(#x80 #xa0)) &rArr; #f
+(bytestring&gt;? #u8(1 2 3) #u8(1 2)) &rArr; #t
+</code></pre>
 
 <h3>Searching</h3>
 
 <p><code>(bytestring-index</code>&nbsp;<var>bytevector pred</var> [<var>start</var> [<var>end</var>]]<code>)</code><br>
 <code>(bytestring-index-right</code>&nbsp;<var>bytevector pred</var> [<var>start</var> [<var>end</var>]]<code>)</code></p>
 <p>Search <var>bytevector</var> from <var>start</var> to <var>end</var> / from <var>end</var> to <var>start</var> for the first byte that satisfies <var>pred</var>, and return the index into <var>bytevector</var> containing that byte. In either direction, <var>start</var> is inclusive and <var>end</var> is exclusive. If there are no such bytes, returns <code>#f</code>.</p>
+<pre class="example"><code>(bytestring-index #u8(#x65 #x72 #x83 #x6f) (lambda (b) (&gt; b #x7f))) &rArr; 2
+(bytestring-index #u8"Beeblebrox" (lambda (b) (&gt; b #x7f))) &rArr; #f
+(bytestring-index-right #u8"Zaphod" odd?) &rArr; 4
+</code></pre>
 
 <p><code>(bytestring-break</code>&nbsp;<var>bytevector pred</var><code>)</code><br>
 <code>(bytestring-span</code>&nbsp;<var>bytevector pred</var><code>)</code></p>
 <p>Return two values, a bytevector containing the maximal sequence of characters (searching from the beginning to the end that do not satisfy / do satisfy <var>pred</var>, and another bytevector containing the remaining characters.</p>
+<!-- FIXME: missing close paren and ambiguity in previous line. -->
+<pre class="example"><code>(bytestring-break #u8(#x50 #x4b 0 0 #x1 #x5) zero?)
+  &rArr; #u8(#x50 #x4b)
+    #u8(0 0 #x1 #x5)
+(bytestring-span #u8"ABCDefg" (lambda (b) (&gt; b 40) (&lt; b 91)))
+  &rArr; #u8"ABCD"
+    #u8"efg"
+</code></pre>
 
 <h3 id="joining-and-splitting">Joining and splitting</h3>
 
@@ -286,10 +302,16 @@ any symbol other than these four:</p>
   <li><code>suffix</code> means a suffix or terminator grammar: insert the delimiter after every list element.</li>
   <li><code>prefix</code> means a prefix grammar: insert the delimiter before every list element.</li>
 </ul>
+<pre class="example"><code>(bytestring-join '(#u8"Heart" #u8"of" #u8"Gold") #x20) &rArr; #u8"Heart of Gold"
+(bytestring-join '(#u8(#xef #xbb) #u8(#xbf)) 0 'prefix) &rArr; #u8(0 #xef #xbb 0 #xbf)
+(bytestring-join '() 0 'strict-infix) &rArr;</code> <em>error</em></pre>
 
 <p><code>(bytestring-split</code>&nbsp;<var>bytevector delimiter</var> [<var>grammar</var>]<code>)</code></p>
 <p>Divides the elements of <var>bytevector</var> and returns a list of newly allocated bytevectors using the <var>delimiter</var> (an ASCII character or exact integer in the range 0-255 inclusive). Delimiter bytes are not included in the result bytevectors.</p>
 <p>The <var>grammar</var> argument is used to control how <var>bytevector</var> is divided. It has the same default and meaning as in <code>bytestring-join</code>, except that <code>infix</code> and <code>strict-infix</code> mean the same thing. That is, if <var>grammar</var> is <code>prefix</code> or <code>suffix</code>, then ignore any delimiter in the first or last position of <var>bytevector</var> respectively.</p>
+<pre class="example"><code>(bytestring-split #u8"Beeblebrox" #x62) &rArr; (#u8"Bee" #u8"le" #u8"rox")
+(bytestring-split #u8(1 0 2 0) 0 'suffix) &rArr; (#u8(1) #u8(2))
+</code></pre>
 
 <h3>I/O</h3>
 
@@ -301,6 +323,11 @@ that <code>#u8</code> has already been read from <var>port</var>.
 If <var>port</var> is omitted, it defaults to the value of <code>(current-input-port)</code>.
 If the characters read are not in the external format,
 an error satisfying <code>bytestring-error?</code> is raised.</p>
+<pre class="example"><code>(call-with-port (open-input-string "#u8\"AB\\xad;\\xf0;\\x0d;CD\"")
+                (lambda (port)
+                  (read-textual-bytestring #t port)))
+  &rArr; #u8(#x41 #x42 #xad #xf0 #x0d #x43 #x44)
+</code></pre>
 
 <p><code>(write-textual-bytestring</code>&nbsp;<var>bytevector</var> [ <var>port</var> ]<code>)</code></p>
 <p>Write <var>bytevector</var> in the external format described in this SRFI to <var>port</var>.
@@ -308,6 +335,14 @@ Bytes representing non-graphical ASCII characters are unencoded:
 all other bytes are encoded with a single letter if possible,
 otherwise with a <code>\x</code> escape.
 If <var>port</var> is omitted, it defaults to the value of <code>(current-output-port)</code>.</p>
+<pre class="example"><code>(call-with-port (open-output-string)
+                (lambda (port)
+                  (write-textual-bytestring
+                   #u8(#x9 #x41 #x72 #x74 #x68 #x75 #x72 #xa)
+                   port)
+                  (get-output-string port)))
+  &rArr; "#u8\"\\tArthur\\n\""
+</code></pre>
 
 <p><code>(write-binary-bytestring</code>&nbsp;<var>port arg</var> …<code>)</code></p>
 <p>Outputs each <var>arg</var> to the binary output port <var>port</var>
@@ -316,6 +351,12 @@ but without creating any bytevectors.
 The <var>args</var> are validated before any bytes are written to
 <var>port</var>; if they are ill-formed, an error satisfying
 <code>bytestring-error?</code> is raised.</p>
+<pre class="example"><code>(call-with-port (open-output-bytevector)
+                (lambda (port)
+                  (write-binary-bytestring port #\Z #x61 #x70 "hod")
+                  (get-output-bytevector port)))
+  &rArr; #u8"Zaphod"
+</code></pre>
 
 <h3>Exception</h3>
 

--- a/srfi-207.html
+++ b/srfi-207.html
@@ -276,8 +276,7 @@ the equivalent R7RS library <code>(scheme bytevector)</code>.
 
 <p><code>(bytestring-break</code>&nbsp;<var>bytevector pred</var><code>)</code><br>
 <code>(bytestring-span</code>&nbsp;<var>bytevector pred</var><code>)</code></p>
-<p>Return two values, a bytevector containing the maximal sequence of characters (searching from the beginning to the end that do not satisfy / do satisfy <var>pred</var>, and another bytevector containing the remaining characters.</p>
-<!-- FIXME: missing close paren and ambiguity in previous line. -->
+<p>Return two values, a bytevector containing the maximal sequence of characters (searching from the beginning of <var>bytevector</var> to the end) that do not satisfy / do satisfy <var>pred</var>, and another bytevector containing the remaining characters.</p>
 <pre class="example"><code>(bytestring-break #u8(#x50 #x4b 0 0 #x1 #x5) zero?)
   &rArr; #u8(#x50 #x4b)
     #u8(0 0 #x1 #x5)

--- a/srfi/207/bytestrings-impl.scm
+++ b/srfi/207/bytestrings-impl.scm
@@ -252,7 +252,12 @@
 (define bytestring-replace
   (case-lambda
     ((bstring1 bstring2 start end)
-     (bytestring-replace bstring1 bstring2 start end start end))
+     (bytestring-replace bstring1
+                         bstring2
+                         start
+                         end
+                         0
+                         (bytevector-length bstring2)))
     ((bstring1 bstring2 start1 end1 start2 end2)
      (assume (bytevector? bstring1))
      (assume (bytevector? bstring2))


### PR DESCRIPTION
These commits add examples to the SRFI document. A few typos and an implementation error (incorrect defaults in bytestring-replace) are also corrected. Thanks.