### PR TITLE
Correct reference to non-existent library

### DIFF
--- a/srfi-207.html
+++ b/srfi-207.html
@@ -247,9 +247,9 @@ if they are ill-formed, an error satisfying
 <h3>Comparison</h3>
 
 <p>To compare bytevectors for equality, use the
-procedure <code>bytevector=?</code> from either
+procedure <code>bytevector=?</code> from
 the R6RS library <code>(rnrs bytevectors)</code> or
-<code>equal?</code> for R7RS.
+<code>equal?</code> in R7RS.
 
 <p><code>(bytestring&lt;?</code> <var>bytevector1 bytevector2</var><code>)</code><br>
 <code>(bytestring&gt;?</code> <var>bytevector1 bytevector2</var><code>)</code><br>

--- a/srfi-207.html
+++ b/srfi-207.html
@@ -249,7 +249,7 @@ if they are ill-formed, an error satisfying
 <p>To compare bytevectors for equality, use the
 procedure <code>bytevector=?</code> from either
 the R6RS library <code>(rnrs bytevectors)</code> or
-the equivalent R7RS library <code>(scheme bytevector)</code>.
+<code>equal?</code> for R7RS.
 
 <p><code>(bytestring&lt;?</code> <var>bytevector1 bytevector2</var><code>)</code><br>
 <code>(bytestring&gt;?</code> <var>bytevector1 bytevector2</var><code>)</code><br>


### PR DESCRIPTION
`(scheme bytevector)` does not exist in R7RS. Bytevector equality is done using `equal?` there AFAIK.

Maybe this is referring to an R7RS-large library, but I think that should be specified if so.